### PR TITLE
Fix compilation error for DSi check

### DIFF
--- a/arm9/source/dsi.cpp
+++ b/arm9/source/dsi.cpp
@@ -31,7 +31,7 @@
 
 bool isDsi()
 {
-	return (REG_DSIMODE != 0) ? true : false;
+	return isDSiMode();
 }
 
 bool dsiUnlockSlot1()


### PR DESCRIPTION
Fixes https://github.com/suloku/savegame-manager/issues/16.

```
error: 'REG_DSIMODE' was not declared in this scope; did you mean 'REG_IME'?
```