### PR TITLE
Update .gitignore to exclude *.elf, *.nds, and .DS_Store.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+arm7/build
+arm7/savegame_manager.elf
+arm9/build
+arm9/savegame_manager.elf
+savegame_manager.nds
+*.exe
+*.dldi
+*.elf

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ savegame_manager.nds
 *.exe
 *.dldi
 *.elf
+*.nds

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ savegame_manager.nds
 *.dldi
 *.elf
 *.nds
+*.DS_Store


### PR DESCRIPTION
These are all non-source files that should not be tracked.